### PR TITLE
examples/nelfilt.pl and assorted fixes

### DIFF
--- a/examples/flowdump.pl
+++ b/examples/flowdump.pl
@@ -36,6 +36,7 @@ while ( $sender = $sock->recv( $packet, 0xFFFF ) ) {
 	$TemplateArrayRefs{$stream_id} ||= [];
 	my $TemplateArrayRef = $TemplateArrayRefs{$stream_id};
 	( $HeaderHashRef, $TemplateArrayRef, $FlowArrayRef, $ErrorsArrayRef ) = Net::Flow::decode( \$packet, $TemplateArrayRef );
+	$TemplateArrayRefs{$stream_id} = $TemplateArrayRef;
 
 	grep { print "$_\n" } @{$ErrorsArrayRef} if ( @{$ErrorsArrayRef} );
 

--- a/examples/flowdump.pl
+++ b/examples/flowdump.pl
@@ -1,3 +1,5 @@
+#!/usr/bin/perl
+
 use strict;
 use warnings;
 
@@ -16,6 +18,7 @@ my $sock = IO::Socket::INET->new(
 	Proto     => 'udp'
 );
 
+my $frameno = 0;
 my $sender;
 while ( $sender = $sock->recv( $packet, 0xFFFF ) ) {
 	my ($sender_port, $sender_addr) = unpack_sockaddr_in($sender);
@@ -37,6 +40,8 @@ while ( $sender = $sock->recv( $packet, 0xFFFF ) ) {
 	my $TemplateArrayRef = $TemplateArrayRefs{$stream_id};
 	( $HeaderHashRef, $TemplateArrayRef, $FlowArrayRef, $ErrorsArrayRef ) = Net::Flow::decode( \$packet, $TemplateArrayRef );
 	$TemplateArrayRefs{$stream_id} = $TemplateArrayRef;
+
+	print "\n- Frame @{[++$frameno]}: -\n";
 
 	grep { print "$_\n" } @{$ErrorsArrayRef} if ( @{$ErrorsArrayRef} );
 

--- a/examples/nelfilt.pl
+++ b/examples/nelfilt.pl
@@ -1,0 +1,163 @@
+#!/usr/bin/perl
+
+# nelfilt.pl: Translate flow stream from $bind_addr:$receive_port to
+# $send_addr:$send_port, filtering out all flows except "NAT events".
+
+use strict; no strict 'subs';
+use Net::Flow qw(decode encode search_template);
+use Net::Flow::Constants;
+use IO::Socket::INET;
+
+# command-line arguments
+my $bind_addr    = "127.0.0.2";
+my $receive_port = 2055;
+my $send_addr    = "127.0.0.1";
+my $send_port    = 2055;
+
+# list of interesting IDs used by sub filter
+my @filter_ids =
+    map($Net::Flow::Constants::informationElementsByName{$_}{elementId},
+        "postNATSourceIPv4Address",
+        "postNATSourceIPv6Address",
+        "postNATDestinationIPv4Address",
+        "postNATDestinationIPv6Address");
+
+# templates learned from input packets
+# $templates{$source_id}[template_hash, ...]
+my %templates;
+
+# templates for output packets
+# $otemplates{$source_id}{$id} = template_hash
+my %otemplates;
+
+
+
+sub usage {
+    die "Usage: nelfilt [-b BIND_IPADDR] [-p INPORT] [TARGET_IPADDR[:PORT]]\n";
+}
+
+
+sub parse_args {
+    while (local $_ = shift @ARGV) {
+        if (s/^-b(\d+\.\d+\.\d+\.\d+)?$//) {
+            $bind_addr = $1 || shift @ARGV || usage();
+        }
+        elsif (s/^-p(\d*)$//) {
+            $receive_port = $1 || shift @ARGV || usage();
+        }
+        elsif (s/^(\d+\.\d+\.\d+\.\d+)$//) {
+            $send_addr = $1;
+        }
+        elsif (s/^(\d+\.\d+\.\d+\.\d+):(\d+)$//) {
+            $send_addr = $1;
+            $send_port = $2;
+        }
+        else {
+            usage();
+        }
+    }
+}
+
+# Return stream identification based on packet header.  This is
+# necessary when handling mixed data stram from several sources: every
+# source uses its own set of templates.  No separation for netflow v5
+# sources: they all use the same fixed template.
+sub stream_id {
+    my ($packet, $sender) = @_;
+    my ($sender_port, $sender_addr) = unpack_sockaddr_in($sender);
+    $sender_addr = inet_ntoa($sender_addr);
+    my ($version, $observationDomainId, $sourceId) = unpack('nx10N2', $packet);
+    return ($version == 9? "$sender_port $sender_addr $sourceId":
+            $version == 10? "$sender_port $sender_addr $observationDomainId":
+            "v5");
+}
+
+
+# given [a reference to] a list of flows returned by from
+# Net::Flow::decode, return the list of "interesting" flows.
+# Currently we are interested only in NAT event flows which are
+# recognized by presence of certain IDs.
+sub filter {
+    my ($flows) = @_;
+    my @out;
+    for my $flow (@$flows) {
+        if (grep {$flow->{$_}} @filter_ids) {
+            push @out, $flow;
+        }
+    }
+    return @out;
+}
+
+
+sub main {
+    parse_args();
+
+    my $sock  = IO::Socket::INET->new(Proto => "udp",
+                                      LocalAddr => $bind_addr,
+                                      LocalPort => $receive_port)
+        or die "udp $bind_addr:$receive_port: $!\n";
+
+    my $osock = IO::Socket::INET->new(Proto => "udp",
+                                      PeerAddr => $send_addr,
+                                      PeerPort => $send_port)
+        or die "udp $send_addr:$send_port: $!\n";
+
+    # Net::Flow::encode receives keeps state data in encode_header, so
+    # define it outside the loop.
+    my %encode_header = (TemplateResendSecs => 3);
+
+    while (my $sender = $sock->recv(my $packet, 0xFFFF)) {
+        my $version = unpack("n", $packet);
+        if ($version != 9 && $version != 10) {
+            warn "v$version packet ignored\n";
+            next;
+        }
+
+        my $stream_id = stream_id($packet, $sender);
+        my ($header, $updated_templates, $flows, $errs) =
+            decode(\$packet, \@{$templates{$stream_id}});
+        map {warn "$_\n"} grep !/NOT FOUND TEMPLATE/, @$errs;
+        $templates{$stream_id} = $updated_templates;
+
+        my @oflows = filter($flows);
+        next unless @oflows;
+
+        for (@oflows) {
+            my $id = $_->{SetId};
+            if (! $otemplates{$stream_id}{$id}) {
+                my ($templ, $err) =
+                    search_template($id, $templates{$stream_id});
+                if ($err) {
+                    warn "$_\n";
+                }
+                $otemplates{$stream_id}{$id} = $templ;
+            }
+        }
+
+        my @otempl = values %{$otemplates{$stream_id}};
+        # Net::Flow::encode increments SequenceNum.
+        # We don't want it changed, work around...
+        if ($header->{SequenceNum}) {
+            $header->{SequenceNum}--;
+        }
+        %encode_header = (%encode_header, %$header);
+
+        my (undef, $pkts, $errs2) =
+            encode(\%encode_header, \@otempl, \@oflows, 1468);
+        map {print "$_\n"} @$errs2;
+
+        for (@$pkts) {
+            $osock->send($$_); # Reference-happy Net::Flow...
+        }
+    }
+}
+
+main();
+exit 0;
+
+# Local Variables: ***
+# mode:Perl ***
+# perl-indent-level:4 ***
+# End: ***
+#
+# vim: ts=4 sw=4 expandtab

--- a/lib/Net/Flow.pm
+++ b/lib/Net/Flow.pm
@@ -27,9 +27,13 @@ use Time::HiRes qw(tv_interval gettimeofday);
 use Digest::MD5 qw(md5_hex);
 use Data::Dumper;
 
-use Exporter;
+our (@ISA, @EXPORT_OK);
+BEGIN {
+  require Exporter;
+  @ISA = qw(Exporter);
+  @EXPORT_OK = qw(decode encode search_template);
+}
 
-our @EXPORT_OK = qw(decode encode);
 our $VERSION   = '1.002';
 
 use constant NetFlowv5 => 5;

--- a/lib/Net/Flow.pm
+++ b/lib/Net/Flow.pm
@@ -94,8 +94,7 @@ sub encode {
 	$InputHeaderRef->{TemplateResendSecs} = 0
 		unless defined $InputHeaderRef->{TemplateResendSecs};
 
-	$InputHeaderRef->{_sysstarttime} ||= [gettimeofday];
-  check_header($InputHeaderRef) unless defined $InputHeaderRef->{_header_len};
+	check_header($InputHeaderRef) unless defined $InputHeaderRef->{_header_len};
 
 	my $sendTemplates = 1;    # Always is the default
 
@@ -303,7 +302,10 @@ sub check_header {
 		$InputHeaderRef->{SourceId}    ||= 0;
 		$InputHeaderRef->{SequenceNum} ||= 0;
 		$InputHeaderRef->{_export_time} = $InputHeaderRef->{UnixSecs} || time;
-		$InputHeaderRef->{SysUpTime} = int( tv_interval( $InputHeaderRef->{_sysstarttime} ) * 1000 );
+		$InputHeaderRef->{SysUpTime} ||= do {
+			my ($sec, $usec) = gettimeofday;
+			int($sec * 1000 + $usec / 1000);
+		};
 	}
 
 	return ( \@Errors );

--- a/lib/Net/Flow.pm
+++ b/lib/Net/Flow.pm
@@ -667,8 +667,8 @@ sub decode {
 
 			if ( ( length($$NetFlowPktRef) - $OffSet ) < 4 ) {
 
-				if ( $FlowCount ne $NetFlowHeaderRef->{Count} ) {
-					$Error = 'WARNING : UNMATCH FLOW COUNT';
+				if ( ! @Errors && $FlowCount ne $NetFlowHeaderRef->{Count} ) {
+					$Error = 'WARNING : FLOW COUNT MISMATCH';
 					push( @Errors, $Error );
 				}
 
@@ -772,8 +772,8 @@ sub decode {
 
 			if ( ( length($$NetFlowPktRef) - $OffSet ) < 4 ) {
 
-				if ( $FlowCount ne $NetFlowHeaderRef->{Count} ) {
-					$Error = 'WARNING : UNMATCH FLOW COUNT';
+				if ( ! @Errors && $FlowCount ne $NetFlowHeaderRef->{Count} ) {
+					$Error = 'WARNING : FLOW COUNT MISMATCH';
 					push( @Errors, $Error );
 				}
 

--- a/lib/Net/Flow.pm
+++ b/lib/Net/Flow.pm
@@ -661,14 +661,14 @@ sub decode {
 	# insert template data
 	#
 
-	if ( defined($InputTemplateRef) || ref($InputTemplateRef) eq 'ARRAY' ) {
-
-		push( @Template, @{$InputTemplateRef} );
-
-	} elsif ( defined($InputTemplateRef) ) {
+	if ( ref($InputTemplateRef) ne 'ARRAY' ) {
 
 		$Error = 'WARNING : NOT REF TEMPLATE DATA';
 		push( @Errors, $Error );
+
+	} else {
+
+		push( @Template, @{$InputTemplateRef} );
 
 	}
 

--- a/lib/Net/Flow.pm
+++ b/lib/Net/Flow.pm
@@ -1418,7 +1418,7 @@ and sampling mode. And they are sent to the next Collector.
 
 The Flow module provides the decoding function for NetFlow version 5,9
 and IPFIX, and the encoding function for NetFlow version 9 and
-IPFIX. It supports NetFlow version 9 (RFC3945) and NetFlow version 5
+IPFIX. It supports NetFlow version 9 (RFC3954) and NetFlow version 5
 (http://www.cisco.com/) and IPFIX(RFC5101). You can easily make the
 Flow Proxy, Protocol Converter and Flow Concentrator by using the
 combination of both function, just like Flow Mediator (RFC6183). The

--- a/lib/Net/Flow.pm
+++ b/lib/Net/Flow.pm
@@ -96,52 +96,6 @@ sub encode {
 
 	check_header($InputHeaderRef) unless defined $InputHeaderRef->{_header_len};
 
-	my $sendTemplates = 1;    # Always is the default
-
-	my $template_info;
-
-	# if TemplateResendSecs is true someone has bothered to define it so
-	# we can do some extra work to see if we really need to send
-	# template info.
-	if ( $InputHeaderRef->{TemplateResendSecs} ) {
-		my $templates_id = scalar $InputTemplateRef;
-		##warn "templates_id: $templates_id\n";
-		$InputHeaderRef->{_template_info}->{$templates_id} ||= {};
-		$template_info = $InputHeaderRef->{_template_info}->{$templates_id};
-		my $hash = md5_hex( Dumper($InputTemplateRef) );
-		##warn Dumper($InputTemplateRef) unless defined $template_info->{hash};
-		$template_info->{hash} ||= $hash;
-		if ( $template_info->{hash} ne $hash ) {
-			##warn "$template_info->{hash} ne $hash", "\n";
-			##warn Dumper($InputTemplateRef);
-			$template_info->{hash} = $hash;
-			delete $template_info->{_template_sent};
-		}
-
-		# This is a kludge until I come up with something better.  Using
-		# the stringified $InputTemplateRef as an ID works, but if someone
-		# is passing in a new ref everytime this will slowly leak memory.
-		#
-		# I have arbitrarily chosen 50 as too many sets of template
-		# information to have.  Hopefully this will keep the amount of
-		# looping through the _template_info hash to a minimum and also
-		# prevent memory from leaking endlessly.
-		if ( keys %{ $InputHeaderRef->{_template_info} } > 50 ) {
-			for my $key ( keys %{ $InputHeaderRef->{_template_info} } ) {
-				my $sent = $InputHeaderRef->{_template_info}->{$key}->{_template_sent};
-				if ( time - $sent > $InputHeaderRef->{TemplateResendSecs} ) {
-					delete $InputHeaderRef->{_template_info}->{$key};
-				}
-			}
-		}
-
-		$sendTemplates = (
-			( !defined $template_info->{_template_sent} )
-			? 1
-			: ( ( time - $template_info->{_template_sent} ) >= $InputHeaderRef->{TemplateResendSecs} )
-		);
-	}
-
 	#
 	# check header reference
 	#
@@ -150,14 +104,9 @@ sub encode {
 
 	push( @Errors, @{$ErrorRef} ) if ( defined $ErrorRef );
 
-	my @flowRef;
-	if ($sendTemplates) {
-		push @flowRef, @{$InputTemplateRef};
-		$template_info->{_template_sent} = time if ref $template_info eq 'HASH';
-	}
-	push @flowRef, @{$InputFlowRef};
+	my @flowRef = @{$InputFlowRef};
 
-	##warn scalar localtime ($template_info->{_template_sent}), "\n";
+	my %TemplatesNeeded;
 
 	foreach my $FlowRef (@flowRef) {
 		my $PackRef           = undef;
@@ -186,6 +135,11 @@ sub encode {
 
 				( $PackRef, $ErrorRef ) = &flow_encode( $FlowRef, $DecodeTemplateRef );
 
+				push( @FlowPacks, $PackRef )	if defined $PackRef;
+				push( @Errors, @{$ErrorRef} ) if defined $ErrorRef;
+
+				$TemplatesNeeded{$FlowRef->{SetId}} = 1;
+
 			} else {
 
 				$Error = "ERROR : NO TEMPLATE TEMPLATE ID=$FlowRef->{SetId}";
@@ -193,21 +147,13 @@ sub encode {
 
 			}
 
-			#
-			# encode template data
-			#
-
-		} else {
-
-			( $PackRef, $ErrorRef ) = &template_encode( $FlowRef, $InputHeaderRef );
-
 		}
 
-		push( @FlowPacks, $PackRef )
-			if defined $PackRef;
+		else {
 
-		push( @Errors, @{$ErrorRef} ) if defined $ErrorRef;
+			push( @Errors, 'ERROR : NON-DATASET ID IN FLOWREF: ' . $FlowRef->{SetId} );
 
+		}
 	}
 
 	unless (@FlowPacks) {
@@ -215,6 +161,33 @@ sub encode {
 		$Error = 'ERROR : NO FLOW DATA';
 		push( @Errors, $Error );
 		return ( $InputHeaderRef, \@Payloads, \@Errors );
+
+	}
+
+	#
+	# encode template data
+	#
+
+	foreach my $TemplateFlowRef (@{$InputTemplateRef}) {
+
+		next unless $TemplatesNeeded{$TemplateFlowRef->{TemplateId}};
+
+		my ( $PackRef, $ErrorRef ) = &template_encode( $TemplateFlowRef, $InputHeaderRef );
+
+		if ( my $secs = $InputHeaderRef->{TemplateResendSecs} ) {
+			my $id = $TemplateFlowRef->{TemplateId};
+			if ( $InputHeaderRef->{_template_sent}{$id} ) {
+				my ( $prevpack, $when ) = @{$InputHeaderRef->{_template_sent}{$id}};
+				my $now = $InputHeaderRef->{UnixSecs};
+				if ( $PackRef->{Pack} eq $prevpack && ($now - $when) < $secs ) {
+					next;
+				}
+			}
+			my $now = $InputHeaderRef->{UnixSecs};
+			$InputHeaderRef->{_template_sent}{$id} = [$PackRef->{Pack}, $now];
+		}
+
+		unshift( @FlowPacks, $PackRef );
 
 	}
 


### PR DESCRIPTION
Greetings!

I have written a script using Net::Flow and thought it may be useful as an example.

I also made some changes to Flow.pm, not changing the API.  The only nontrivial one is in template emission code (273ef2c4e).  The former code would resend all templates should any one of templates change.  The new code is selective, sending only the templates that changed (or timed out) and actually required by flows present in the current batch.  Template retransmission timeouts are now based on $header{UnixSecs}, not time(2), and so can handle recorded historic flows properly.

Thank you for githubizing and maintaining the code.

All the best,

-- Yury